### PR TITLE
allow passing shopper statement (descricao do boleto) when generating boleto

### DIFF
--- a/lib/adyen/api.rb
+++ b/lib/adyen/api.rb
@@ -89,13 +89,14 @@ module Adyen
     #
     # @return [PaymentService::BilletResponse] The response object which holds the billet url.
     #
-    def generate_billet(reference, amount, shopper_name, social_security_number, selected_brand, delivery_date)
+    def generate_billet(reference, amount, shopper_name, social_security_number, selected_brand, delivery_date, shopper_statement='')
       params = { :reference              => reference,
                  :amount                 => amount,
                  :shopper_name           => shopper_name,
                  :social_security_number => social_security_number,
                  :selected_brand         => selected_brand,
-                 :delivery_date          => delivery_date }
+                 :delivery_date          => delivery_date,
+                 :shopper_statement      => shopper_statement}
       PaymentService.new(params).generate_billet
     end
 


### PR DESCRIPTION
the idea is to when we call the `Adyen::API::generate_billet`, we can inform the `shopperStatement` field of the boleto as documented here https://docs.adyen.com/payment-methods/boleto-bancario/